### PR TITLE
Editorial: Clarify the definition of Synthetic Module Record

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -89,9 +89,9 @@
   <emu-clause id="sec-synthetic-module-records">
     <h1>Synthetic Module Records</h1>
 
-    <emu-note type="editor">This Synthetic Module Records specification text comes from the <a href="https://github.com/tc39/proposal-javascript-standard-library/">JavaScript Standard Library proposal</a> and was written by Domenic Denicola. A version of this text exists <a href="https://heycam.github.io/webidl/#synthetic-module-records">in WebIDL</a>. A version of the text is copied here to clarify that the concept of Synthetic Module Records can proceed in standardization independently of the built-in modules effort.</emu-note>
+    <emu-note type="editor">This Synthetic Module Records specification text comes from the <a href="https://github.com/tc39/proposal-javascript-standard-library/">JavaScript Standard Library proposal</a> and was written by Domenic Denicola. A version of the text is copied here to clarify that the concept of Synthetic Module Records can proceed in standardization independently of the built-in modules effort.</emu-note>
 
-    <p>A <dfn>Synthetic Module Record</dfn> is used to represent information about a module that is defined by specifications. Its exports are derived from a pair of lists, of string keys and of ECMAScript values. The set of exported names is static, and determined at creation time (as an argument to CreateSyntheticModule), while the set of exported values can be changed over time using SetSyntheticModuleExport. It has no imports or dependencies.</p>
+    <p>A <dfn>Synthetic Module Record</dfn> is used to represent information about a module that is defined by specifications. Its exported names are statically defined at creation as an argument to CreateSyntheticModule, while their corresponding values can change over time using SetSyntheticModuleExport. It has no imports or dependencies.</p>
 
     <emu-note>A Synthetic Module Record could be used for defining a variety of module types: for example, built-in modules, or JSON modules, or CSS modules.</emu-note>
 


### PR DESCRIPTION
* Remove outdated reference to Web IDL (the text was removed in 2020 by https://github.com/whatwg/webidl/commit/5021df45cd01bd690b28c5adc4d7ec5dd8ae3892 ).
* Remove reference to nonexistent list of ECMAScript values (which instead exist in the Environment Record).